### PR TITLE
Update DVDatePickerTableViewCell.swift

### DIFF
--- a/DVDatePickerTableViewCell/DVDatePickerTableViewCell.swift
+++ b/DVDatePickerTableViewCell/DVDatePickerTableViewCell.swift
@@ -257,7 +257,9 @@ class DVDatePickerTableViewCell: UITableViewCell {
             ])
         
         datePicker.addTarget(self, action: "datePicked", forControlEvents: UIControlEvents.ValueChanged)
-        self.date = NSDate()
+        
+        let timeIntervalSinceReferenceDateWithoutSeconds = floor(date.timeIntervalSinceReferenceDate / 60.0) * 60.0 // Clear the seconds (":00")
+        self.date = NSDate(timeIntervalSinceReferenceDate: timeIntervalSinceReferenceDateWithoutSeconds)
         leftLabel.text = "Date Picker"
     }
     


### PR DESCRIPTION
Inserted two lines of code, for setting the seconds to "0".
Without it, the seconds will be set with NSDate() at the first call and never changed afterwards.
